### PR TITLE
FIX: Adjustments for Windows

### DIFF
--- a/astra/tools.py
+++ b/astra/tools.py
@@ -20,9 +20,15 @@ def execute(cmd, cwd=None):
     Useful in Jupyter notebook
     
     """
-    popen = subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True, cwd=cwd)
+    popen = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True, cwd=cwd)
+    if os.name == 'nt':
+        # When running Astra with Windows it requires us to Press return at the end of execution
+        popen.stdin.write("\n")
+        popen.stdin.flush()
+        popen.stdin.close()
     for stdout_line in iter(popen.stdout.readline, ""):
         yield stdout_line 
+    popen.stdin.close()
     popen.stdout.close()
     return_code = popen.wait()
     if return_code:
@@ -39,7 +45,7 @@ def execute2(cmd, timeout=None, cwd=None):
         p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True, timeout = timeout, cwd=cwd)
         output['log'] = p.stdout
         output['error'] = False
-        output['why_error'] =''
+        output['why_error'] = ''
     except subprocess.TimeoutExpired as ex:
         output['log'] = ex.stdout+'\n'+str(ex)
         output['why_error'] = 'timeout'

--- a/astra/writers.py
+++ b/astra/writers.py
@@ -95,8 +95,14 @@ def write_namelists(namelists, filePath, make_symlinks=False, prefixes=['file_',
     Simple function to write namelist lines to a file
     
     If make_symlinks, prefixes will be searched for paths and the appropriate links will be made.
-    
+    For Windows, make_symlinks is ignored and it is always False.See note at https://docs.python.org/3/library/os.html#os.symlink .
     """
+    # With Windows 10, users need Administator Privileges or run on Developer mode
+    # in order to be able to create symlinks.
+    # More info: https://docs.python.org/3/library/os.html#os.symlink
+    if os.name == 'nt':
+        make_symlinks = False
+
     with open(filePath, 'w') as f:
         for key in namelists:
             namelist = namelists[key]
@@ -247,10 +253,3 @@ def write_screens_h5(h5, astra_screens, name='screen'):
     for i in range(len(astra_screens)):
         name = str(i)        
         write_astra_particles_h5(g, name, astra_screens[i])   
-        
-         
-        
-        
-        
-        
-        


### PR DESCRIPTION
Closes #2 

This Pull Request addresses the issue reported at #2 that happened due to the fact that execution of Astra on Windows requires that users "Press return to continue". Without passing `stdin` to `subprocess.Popen` that causes an exit code 24 which means "socket write failed".

After adding stdin the execution would get stuck waiting for the key press. That is addressed via writing to stdin the required key.

Another issue addressed here is that for Windows 10 and higher there are special requirements to allow users to create symlinks. See note section here: https://docs.python.org/3/library/os.html#os.symlink.
In order to not impose system changes or Administrator permission on users this PR forces the `make_symlinks` flag to False when running on Windows.