### PR TITLE
Vector parsing for astra dipoles

### DIFF
--- a/astra/writers.py
+++ b/astra/writers.py
@@ -28,8 +28,8 @@ def namelist_lines(namelist_dict, name):
         elif type(value) == type([]) or isinstance(value, np.ndarray): # lists or np arrays
             liststr = ''
             for item in value:
-                liststr += str(item) + ' '
-            line = key + ' = ' + liststr 
+                liststr = liststr + str(item) + ','
+            line = key + ' = ' + "(" + liststr[:-1] + ")"
         elif type(value) == type('a'): # strings
             line = key + ' = ' + "'" + value.strip("''") + "'"  # input may need apostrophes
        


### PR DESCRIPTION
Changes the way lists or arrays are parsed by separating the values by commas and adding round brackets. This way astra can interpret arrays correctly. 

Note: Dipole coordinates then have to be provided without any brackets, e.g. P1 = 0.1, 0,3