### PR TITLE
Added active particle selection when adding Particles to Astra.plot()

### DIFF
--- a/astra/plot.py
+++ b/astra/plot.py
@@ -230,8 +230,7 @@ def plot_stats_with_layout(astra_object, ykeys=['sigma_x', 'sigma_y'], ykeys2=['
     if include_particles:
         try:
             for pname in range(len(I.particles)): # Modified from Impact
-                xp_alive = I.output["particles"][pname].where(I.output["particles"][pname].status == 1)
-                xp = xp_alive[xkey]
+                xp = I.particles[pname].where(I.particles[pname].status == 1)[xkey]
                 if xp >= xlim[0] and xp <= xlim[1]:
                     Pnames.append(pname)
                     X_particles.append(xp)
@@ -299,7 +298,7 @@ def plot_stats_with_layout(astra_object, ykeys=['sigma_x', 'sigma_y'], ykeys2=['
             # Particles
             if Pnames:
                 try:
-                    Y_particles = np.array([I.particles[name][key] for name in Pnames])
+                    Y_particles = np.array([I.particles[name].where(I.particles[name].status == 1)[key] for name in Pnames])
                     ax.scatter(X_particles/factor_x, Y_particles/factor, color=color) 
                 except:
                     pass    

--- a/astra/plot.py
+++ b/astra/plot.py
@@ -230,7 +230,8 @@ def plot_stats_with_layout(astra_object, ykeys=['sigma_x', 'sigma_y'], ykeys2=['
     if include_particles:
         try:
             for pname in range(len(I.particles)): # Modified from Impact
-                xp = I.particles[pname][xkey]
+                xp_alive = I.output["particles"][pname].where(I.output["particles"][pname].status == 1)
+                xp = xp_alive[xkey]
                 if xp >= xlim[0] and xp <= xlim[1]:
                     Pnames.append(pname)
                     X_particles.append(xp)


### PR DESCRIPTION
So I noticed that when using Astra.plot() with particles the dots for the particles get more and more crowded as soon as the beam hits an aperture. 

<img width="400" alt="Screenshot 2025-04-01 at 16 14 58" src="https://github.com/user-attachments/assets/5fac4a2b-1c86-41dc-a400-8b45094f4f82" />

Not sure if this is intentional but I think this is because the particles that hit the aperture aren't tracked anymore so they retain all their phase space values including the position x, y, and z. This leads to mean_x,y,z calculated from the Particle object being incorrect since it includes both, active and passive particles. I changed these parts and added a filter which only selects active particles, now the dots match the solid line generated from Astra.stats.

<img width="400" alt="Screenshot 2025-04-01 at 16 40 43" src="https://github.com/user-attachments/assets/a84df916-24c6-4e23-86d1-a17d92ffc783" />


